### PR TITLE
temporarily walkaround for tinyusb init for v4.2

### DIFF
--- a/cores/esp32/esp32-hal-tinyusb.c
+++ b/cores/esp32/esp32-hal-tinyusb.c
@@ -536,11 +536,22 @@ esp_err_t tinyusb_init(tinyusb_device_config_t *config) {
     tinyusb_config_t tusb_cfg = {
             .external_phy = false // In the most cases you need to use a `false` value
     };
+
     esp_err_t err = tinyusb_driver_install(&tusb_cfg);
+
+#if 1 // walkaround for v4.2 tinyusb init bug
+    // Note: IDF v4.2 has a bug that incorrectly check the tusb_init() returned value (bool instead of error code)
+    // https://github.com/espressif/esp-idf/blob/release/v4.2/components/tinyusb/port/esp32s2/src/tinyusb.c#L89
+    // This is due to a internal bug of tinyusb stack which is fixed recently.
+    // This is fixed in IDF v4.3 and should be reverted when 4.3 is released
+    err = ESP_OK;
+#endif
+
     if (err != ESP_OK) {
         initialized = false;
         return err;
     }
+
     xTaskCreate(usb_device_task, "usbd", 4096, NULL, configMAX_PRIORITIES - 1, NULL);
     return err;
 }


### PR DESCRIPTION
add walkaround for v4.2 tusb_init() incorrect returned value. This issue is originated by tinyusb stack with incorrect value returned (bool instead of error code). This is fix by tinyusb but IDF v4.2 hasn't updated yet, this is already fixed in IDF v4.3. This walkaround forcely assume tinyusb init is always successful. This will help to keep the current code running when the IDF v4.3 is rolled out.

see also https://github.com/espressif/arduino-esp32/issues/4728 