### PR TITLE
fix ADC 13 bit width for esp32s2

### DIFF
--- a/cores/esp32/esp32-hal-adc.c
+++ b/cores/esp32/esp32-hal-adc.c
@@ -43,7 +43,13 @@ static uint8_t __analogVRefPin = 0;
 #endif
 
 static uint8_t __analogAttenuation = 3;//11db
+
+#if CONFIG_IDF_TARGET_ESP32
 static uint8_t __analogWidth = 3;//12 bits
+#elif CONFIG_IDF_TARGET_ESP32S2
+static uint8_t __analogWidth = 4;//13 bits
+#endif
+
 static uint8_t __analogClockDiv = 1;
 
 void __analogSetClockDiv(uint8_t clockDiv){


### PR DESCRIPTION
IDF insist width for ADC must be exactly 13, this is a fix/hack to get it running.

See also  https://github.com/espressif/arduino-esp32/issues/4265 