### PR TITLE
Adafruit add init variant capability

### DIFF
--- a/variants/adafruit_feather_esp32s2/pins_arduino.h
+++ b/variants/adafruit_feather_esp32s2/pins_arduino.h
@@ -25,6 +25,7 @@
 #define NEOPIXEL_NUM        1     // number of neopixels
 #define NEOPIXEL_POWER      21    // power pin
 #define NEOPIXEL_POWER_ON   HIGH  // power pin state when on
+#define PIN_I2C_POWER       7     // Ppwer pin for I2C
 
 static const uint8_t SDA = 3;
 static const uint8_t SCL = 4;

--- a/variants/adafruit_feather_esp32s2/variant.cpp
+++ b/variants/adafruit_feather_esp32s2/variant.cpp
@@ -1,0 +1,37 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+#include "esp32-hal-gpio.h"
+#include "pins_arduino.h"
+
+extern "C" {
+
+// Initialize variant/board, called before setup()
+void initVariant(void)
+{
+
+}
+
+}

--- a/variants/adafruit_feather_esp32s2/variant.cpp
+++ b/variants/adafruit_feather_esp32s2/variant.cpp
@@ -31,7 +31,15 @@ extern "C" {
 // Initialize variant/board, called before setup()
 void initVariant(void)
 {
+  // This board has a power control pin, and we must set it to output and high
+  // in order to enable the NeoPixels.
+  pinMode(NEOPIXEL_POWER, OUTPUT);
+  digitalWrite(NEOPIXEL_POWER, HIGH);
 
+  // This board has a power control pin, and we must set it to output and low
+  // in order to enable the I2C port.
+  pinMode(PIN_I2C_POWER, OUTPUT);
+  digitalWrite(PIN_I2C_POWER, LOW);
 }
 
 }

--- a/variants/adafruit_feather_esp32s2_reversetft/variant.cpp
+++ b/variants/adafruit_feather_esp32s2_reversetft/variant.cpp
@@ -1,0 +1,37 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+#include "esp32-hal-gpio.h"
+#include "pins_arduino.h"
+
+extern "C" {
+
+// Initialize variant/board, called before setup()
+void initVariant(void)
+{
+
+}
+
+}

--- a/variants/adafruit_feather_esp32s2_tft/variant.cpp
+++ b/variants/adafruit_feather_esp32s2_tft/variant.cpp
@@ -1,0 +1,37 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+#include "esp32-hal-gpio.h"
+#include "pins_arduino.h"
+
+extern "C" {
+
+// Initialize variant/board, called before setup()
+void initVariant(void)
+{
+
+}
+
+}

--- a/variants/adafruit_funhouse_esp32s2/variant.cpp
+++ b/variants/adafruit_funhouse_esp32s2/variant.cpp
@@ -1,0 +1,37 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+#include "esp32-hal-gpio.h"
+#include "pins_arduino.h"
+
+extern "C" {
+
+// Initialize variant/board, called before setup()
+void initVariant(void)
+{
+
+}
+
+}

--- a/variants/adafruit_magtag29_esp32s2/variant.cpp
+++ b/variants/adafruit_magtag29_esp32s2/variant.cpp
@@ -1,0 +1,37 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+#include "esp32-hal-gpio.h"
+#include "pins_arduino.h"
+
+extern "C" {
+
+// Initialize variant/board, called before setup()
+void initVariant(void)
+{
+
+}
+
+}

--- a/variants/adafruit_metro_esp32s2/variant.cpp
+++ b/variants/adafruit_metro_esp32s2/variant.cpp
@@ -1,0 +1,37 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+#include "esp32-hal-gpio.h"
+#include "pins_arduino.h"
+
+extern "C" {
+
+// Initialize variant/board, called before setup()
+void initVariant(void)
+{
+
+}
+
+}

--- a/variants/adafruit_qtpy_esp32s2/variant.cpp
+++ b/variants/adafruit_qtpy_esp32s2/variant.cpp
@@ -1,0 +1,37 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+#include "esp32-hal-gpio.h"
+#include "pins_arduino.h"
+
+extern "C" {
+
+// Initialize variant/board, called before setup()
+void initVariant(void)
+{
+
+}
+
+}

--- a/variants/adafruit_qtpy_esp32s2/variant.cpp
+++ b/variants/adafruit_qtpy_esp32s2/variant.cpp
@@ -25,8 +25,6 @@
 
 #include "esp32-hal-gpio.h"
 #include "pins_arduino.h"
-#include "Arduino.h"
-#include "Wire.h"
 
 extern "C" {
 

--- a/variants/adafruit_qtpy_esp32s2/variant.cpp
+++ b/variants/adafruit_qtpy_esp32s2/variant.cpp
@@ -25,13 +25,18 @@
 
 #include "esp32-hal-gpio.h"
 #include "pins_arduino.h"
+#include "Arduino.h"
+#include "Wire.h"
 
 extern "C" {
 
 // Initialize variant/board, called before setup()
 void initVariant(void)
 {
-
+  // This board has a power control pin, and we must set it to output and high
+  // in order to enable the NeoPixels.
+  pinMode(NEOPIXEL_POWER, OUTPUT);
+  digitalWrite(NEOPIXEL_POWER, HIGH);
 }
 
 }


### PR DESCRIPTION
for some boards, it would be good if there was the ability to do per-board initialization such as setting pins high/low - this just adds placeholders for some boards we have not gotten to and some initializations for ones we've got