### PR TITLE
fix S3 cannot reset to bootrom with USB OTG

### DIFF
--- a/cores/esp32/esp32-hal-tinyusb.c
+++ b/cores/esp32/esp32-hal-tinyusb.c
@@ -61,7 +61,12 @@ typedef struct {
 
 static bool usb_otg_deinit(void * busptr) {
     // Once USB OTG is initialized, its GPIOs are assigned and it shall never be deinited
+    // except when S3 swithicng usb from cdc to jtag while resetting to bootrom
+#if CONFIG_IDF_TARGET_ESP32S3
+    return true;
+#else
     return false;
+#endif
 }
 
 static void configure_pins(usb_hal_context_t *usb)


### PR DESCRIPTION
same changes as https://github.com/espressif/arduino-esp32/pull/8880 for fixing S3 usb otg uploading. While waiting for espressif review, we can merge this first, make it easier for testing new boards.